### PR TITLE
Track current reads/writes

### DIFF
--- a/json-api-client.js
+++ b/json-api-client.js
@@ -124,6 +124,8 @@ module.exports = Emitter = (function() {
 
 },{}],2:[function(_dereq_,module,exports){
 var DEFAULT_TYPE_AND_ACCEPT, Emitter, JSONAPIClient, Model, READ_OPS, RESERVED_TOP_LEVEL_KEYS, Resource, Type, WRITE_OPS, makeHTTPRequest, mergeInto,
+  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+  hasProp = {}.hasOwnProperty,
   indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
   slice = [].slice;
 
@@ -150,40 +152,40 @@ READ_OPS = ['HEAD', 'GET'];
 
 WRITE_OPS = ['POST', 'PUT', 'DELETE'];
 
-JSONAPIClient = (function() {
+JSONAPIClient = (function(superClass) {
   var fn, i, len, method, ref;
+
+  extend(JSONAPIClient, superClass);
 
   JSONAPIClient.prototype.root = '/';
 
   JSONAPIClient.prototype.headers = null;
 
-  JSONAPIClient.prototype.status = null;
+  JSONAPIClient.prototype.reads = 0;
+
+  JSONAPIClient.prototype.writes = 0;
 
   JSONAPIClient.prototype._typesCache = null;
 
   function JSONAPIClient(root, headers1) {
     this.root = root;
     this.headers = headers1 != null ? headers1 : {};
-    this.status = new Model({
-      reads: 0,
-      writes: 0
-    });
+    JSONAPIClient.__super__.constructor.call(this);
     this._typesCache = {};
   }
 
   JSONAPIClient.prototype.request = function(method, url, payload, headers) {
-    var allHeaders, args, fullURL, request;
+    var allHeaders, fullURL, request;
     method = method.toUpperCase();
     fullURL = this.root + url;
     allHeaders = mergeInto({}, DEFAULT_TYPE_AND_ACCEPT, this.headers, headers);
-    args = arguments;
     if (indexOf.call(READ_OPS, method) >= 0) {
-      this.status.update({
-        reads: this.status.reads + 1
+      this.update({
+        reads: this.reads + 1
       });
     } else if (indexOf.call(WRITE_OPS, method) >= 0) {
-      this.status.update({
-        writes: this.status.writes + 1
+      this.update({
+        writes: this.writes + 1
       });
     }
     request = makeHTTPRequest(method, fullURL, payload, allHeaders);
@@ -194,12 +196,12 @@ JSONAPIClient = (function() {
     })(this)).then((function(_this) {
       return function() {
         if (indexOf.call(READ_OPS, method) >= 0) {
-          return _this.status.update({
-            reads: _this.status.reads - 1
+          return _this.update({
+            reads: _this.reads - 1
           });
         } else if (indexOf.call(WRITE_OPS, method) >= 0) {
-          return _this.status.update({
-            writes: _this.status.writes - 1
+          return _this.update({
+            writes: _this.writes - 1
           });
         }
       };
@@ -330,7 +332,7 @@ JSONAPIClient = (function() {
 
   return JSONAPIClient;
 
-})();
+})(Model);
 
 module.exports = JSONAPIClient;
 

--- a/json-api-client.js
+++ b/json-api-client.js
@@ -123,9 +123,11 @@ module.exports = Emitter = (function() {
 
 
 },{}],2:[function(_dereq_,module,exports){
-var DEFAULT_TYPE_AND_ACCEPT, Emitter, JSONAPIClient, Model, RESERVED_TOP_LEVEL_KEYS, Resource, Type, makeHTTPRequest, mergeInto,
-  slice = [].slice,
-  indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+var DEFAULT_TYPE_AND_ACCEPT, Emitter, JSONAPIClient, Model, READ_OPS, RESERVED_TOP_LEVEL_KEYS, Resource, Type, WRITE_OPS, makeHTTPRequest, mergeInto,
+  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+  hasProp = {}.hasOwnProperty,
+  indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
+  slice = [].slice;
 
 makeHTTPRequest = _dereq_('./make-http-request');
 
@@ -146,26 +148,65 @@ DEFAULT_TYPE_AND_ACCEPT = {
 
 RESERVED_TOP_LEVEL_KEYS = ['meta', 'links', 'linked', 'data'];
 
-JSONAPIClient = (function() {
+READ_OPS = ['HEAD', 'GET'];
+
+WRITE_OPS = ['POST', 'PUT', 'DELETE'];
+
+JSONAPIClient = (function(superClass) {
   var fn, i, len, method, ref;
+
+  extend(JSONAPIClient, superClass);
 
   JSONAPIClient.prototype.root = '/';
 
   JSONAPIClient.prototype.headers = null;
+
+  JSONAPIClient.prototype.reads = 0;
+
+  JSONAPIClient.prototype.writes = 0;
 
   JSONAPIClient.prototype._typesCache = null;
 
   function JSONAPIClient(root, headers1) {
     this.root = root;
     this.headers = headers1 != null ? headers1 : {};
+    JSONAPIClient.__super__.constructor.call(this);
     this._typesCache = {};
   }
 
   JSONAPIClient.prototype.request = function(method, url, payload, headers) {
-    var allHeaders, fullURL;
+    var allHeaders, fullURL, request;
+    method = method.toUpperCase();
     fullURL = this.root + url;
     allHeaders = mergeInto({}, DEFAULT_TYPE_AND_ACCEPT, this.headers, headers);
-    return makeHTTPRequest(method, fullURL, payload, allHeaders).then(this.processResponse.bind(this))["catch"](this.handleError.bind(this));
+    if (indexOf.call(READ_OPS, method) >= 0) {
+      this.update({
+        reads: this.reads + 1
+      });
+    } else if (indexOf.call(WRITE_OPS, method) >= 0) {
+      this.update({
+        writes: this.writes + 1
+      });
+    }
+    request = makeHTTPRequest(method, fullURL, payload, allHeaders);
+    request["catch"]((function(_this) {
+      return function() {
+        return null;
+      };
+    })(this)).then((function(_this) {
+      return function() {
+        if (indexOf.call(READ_OPS, method) >= 0) {
+          return _this.update({
+            reads: _this.reads - 1
+          });
+        } else if (indexOf.call(WRITE_OPS, method) >= 0) {
+          return _this.update({
+            writes: _this.writes - 1
+          });
+        }
+      };
+    })(this));
+    return request.then(this.processResponse.bind(this))["catch"](this.handleError.bind(this));
   };
 
   ref = ['get', 'post', 'put', 'delete'];
@@ -291,7 +332,7 @@ JSONAPIClient = (function() {
 
   return JSONAPIClient;
 
-})();
+})(Model);
 
 module.exports = JSONAPIClient;
 

--- a/json-api-client.js
+++ b/json-api-client.js
@@ -124,8 +124,6 @@ module.exports = Emitter = (function() {
 
 },{}],2:[function(_dereq_,module,exports){
 var DEFAULT_TYPE_AND_ACCEPT, Emitter, JSONAPIClient, Model, READ_OPS, RESERVED_TOP_LEVEL_KEYS, Resource, Type, WRITE_OPS, makeHTTPRequest, mergeInto,
-  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-  hasProp = {}.hasOwnProperty,
   indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
   slice = [].slice;
 
@@ -152,40 +150,40 @@ READ_OPS = ['HEAD', 'GET'];
 
 WRITE_OPS = ['POST', 'PUT', 'DELETE'];
 
-JSONAPIClient = (function(superClass) {
+JSONAPIClient = (function() {
   var fn, i, len, method, ref;
-
-  extend(JSONAPIClient, superClass);
 
   JSONAPIClient.prototype.root = '/';
 
   JSONAPIClient.prototype.headers = null;
 
-  JSONAPIClient.prototype.reads = 0;
-
-  JSONAPIClient.prototype.writes = 0;
+  JSONAPIClient.prototype.status = null;
 
   JSONAPIClient.prototype._typesCache = null;
 
   function JSONAPIClient(root, headers1) {
     this.root = root;
     this.headers = headers1 != null ? headers1 : {};
-    JSONAPIClient.__super__.constructor.call(this);
+    this.status = new Model({
+      reads: 0,
+      writes: 0
+    });
     this._typesCache = {};
   }
 
   JSONAPIClient.prototype.request = function(method, url, payload, headers) {
-    var allHeaders, fullURL, request;
+    var allHeaders, args, fullURL, request;
     method = method.toUpperCase();
     fullURL = this.root + url;
     allHeaders = mergeInto({}, DEFAULT_TYPE_AND_ACCEPT, this.headers, headers);
+    args = arguments;
     if (indexOf.call(READ_OPS, method) >= 0) {
-      this.update({
-        reads: this.reads + 1
+      this.status.update({
+        reads: this.status.reads + 1
       });
     } else if (indexOf.call(WRITE_OPS, method) >= 0) {
-      this.update({
-        writes: this.writes + 1
+      this.status.update({
+        writes: this.status.writes + 1
       });
     }
     request = makeHTTPRequest(method, fullURL, payload, allHeaders);
@@ -196,12 +194,12 @@ JSONAPIClient = (function(superClass) {
     })(this)).then((function(_this) {
       return function() {
         if (indexOf.call(READ_OPS, method) >= 0) {
-          return _this.update({
-            reads: _this.reads - 1
+          return _this.status.update({
+            reads: _this.status.reads - 1
           });
         } else if (indexOf.call(WRITE_OPS, method) >= 0) {
-          return _this.update({
-            writes: _this.writes - 1
+          return _this.status.update({
+            writes: _this.status.writes - 1
           });
         }
       };
@@ -332,7 +330,7 @@ JSONAPIClient = (function(superClass) {
 
   return JSONAPIClient;
 
-})(Model);
+})();
 
 module.exports = JSONAPIClient;
 

--- a/json-api-client.js
+++ b/json-api-client.js
@@ -170,7 +170,7 @@ JSONAPIClient = (function(superClass) {
   function JSONAPIClient(root, headers1) {
     this.root = root;
     this.headers = headers1 != null ? headers1 : {};
-    JSONAPIClient.__super__.constructor.call(this);
+    JSONAPIClient.__super__.constructor.call(this, null);
     this._typesCache = {};
   }
 

--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -14,19 +14,16 @@ RESERVED_TOP_LEVEL_KEYS = ['meta', 'links', 'linked', 'data']
 READ_OPS = ['HEAD', 'GET']
 WRITE_OPS = ['POST', 'PUT', 'DELETE']
 
-class JSONAPIClient
+class JSONAPIClient extends Model
   root: '/'
   headers: null
-
-  status: null # Track reads and writes
+  reads: 0
+  writes: 0
 
   _typesCache: null # Types that have been defined
 
   constructor: (@root, @headers = {}) ->
-    @status = new Model
-      reads: 0
-      writes: 0
-
+    super()
     @_typesCache = {}
 
   request: (method, url, payload, headers) ->
@@ -34,11 +31,10 @@ class JSONAPIClient
     fullURL = @root + url
     allHeaders = mergeInto {}, DEFAULT_TYPE_AND_ACCEPT, @headers, headers
 
-    args = arguments
     if method in READ_OPS
-      @status.update reads: @status.reads + 1
+      @update reads: @reads + 1
     else if method in WRITE_OPS
-      @status.update writes: @status.writes + 1
+      @update writes: @writes + 1
 
     request = makeHTTPRequest method, fullURL, payload, allHeaders
 
@@ -47,9 +43,9 @@ class JSONAPIClient
         null
       .then =>
         if method in READ_OPS
-          @status.update reads: @status.reads - 1
+          @update reads: @reads - 1
         else if method in WRITE_OPS
-          @status.update writes: @status.writes - 1
+          @update writes: @writes - 1
 
     request
       .then @processResponse.bind this

--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -23,7 +23,7 @@ class JSONAPIClient extends Model
   _typesCache: null # Types that have been defined
 
   constructor: (@root, @headers = {}) ->
-    super()
+    super null
     @_typesCache = {}
 
   request: (method, url, payload, headers) ->


### PR DESCRIPTION
This makes the client instance keep track of how many read and write requests are out.

It also makes it extend Model so it can emit an event when those numbers change.

This'll be used to display a "Loading..." message.