### PR TITLE
Check the next key to see if the current one should be an array

### DIFF
--- a/json-api-client.js
+++ b/json-api-client.js
@@ -470,7 +470,7 @@ mergeInto = _dereq_('./merge-into');
 
 isIndex = function(string) {
   var integer;
-  integer = Math.abs(parseInt(string, 10));
+  integer = parseInt(string, 10);
   return integer.toString(10) === string && !isNaN(integer);
 };
 
@@ -532,7 +532,7 @@ module.exports = Model = (function(superClass) {
         base = this;
         while (path.length !== 1) {
           if (base[name = path[0]] == null) {
-            base[name] = isIndex(path[0]) ? [] : {};
+            base[name] = isIndex(path[1]) ? [] : {};
           }
           base = base[path.shift()];
         }

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -2,7 +2,7 @@ Emitter = require './emitter'
 mergeInto = require './merge-into'
 
 isIndex = (string) ->
-  integer = Math.abs parseInt string, 10
+  integer = parseInt string, 10
   integer.toString(10) is string and not isNaN integer
 
 removeUnderscoredKeys = (target) ->
@@ -35,7 +35,7 @@ module.exports = class Model extends Emitter
         rootKey = path[0]
         base = this
         until path.length is 1
-          base[path[0]] ?= if isIndex path[0]
+          base[path[0]] ?= if isIndex path[1]
             []
           else
             {}


### PR DESCRIPTION
If you try to do something like `resource.update({'things.2': 'Third thing'})`, and `resource.things` isn't defined, the library's supposed to be smart enough to make an array automatically. This was broken. Now it's fixed.