### PR TITLE
Revert "Return full response on error"

### DIFF
--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -31,7 +31,7 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
           .then resolve
           .catch reject
       else if err?
-        reject response
+        reject err
       else
         resolve response
 


### PR DESCRIPTION
After spending more than a couple minutes looking at this, returning `err` is correct here. `err` is both an `Error` object, and includes the original request and response. How I didn't catch that yesterday I don't know.

I already published 2.0.0, so will publish 3.0.0 after merging.