### PR TITLE
Move superagent from peerDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compile": "coffee --compile --output ./lib ./src",
     "prepublish": "npm run compile"
   },
-  "peerDependencies": {
+  "dependencies": {
     "superagent": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
NPM no longer installs peer dependencies as of v3, so we shouldn't rely on it being available.

Please review @brian-c, cc @eatyourgreens 