### PR TITLE
Fix errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "prepublish": "npm run compile"
   },
   "dependencies": {
+    "normalizeurl": "~0.1.3",
     "superagent": "^1.3.0"
   },
   "devDependencies": {
     "browserify": "^11.1.0",
     "coffee-script": "^1.10.0",
-    "normalizeurl": "~0.1.3",
     "onchange": "^2.0.0"
   },
   "homepage": "https://github.com/zooniverse/json-api-client",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "browserify": "^11.1.0",
     "coffee-script": "^1.10.0",
+    "normalizeurl": "~0.1.3",
     "onchange": "^2.0.0"
   },
   "homepage": "https://github.com/zooniverse/json-api-client",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "npm run compile; onchange ./src/* -- npm run compile",
-    "build-browser-standalone": "npm run compile && browserify --entry ./lib/json-api-client.js --standalone JSONAPIClient | derequire > ./json-api-client.js",
     "compile": "coffee --compile --output ./lib ./src",
     "prepublish": "npm run compile"
   },

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -1,46 +1,38 @@
 request = require 'superagent'
-coreUrl = require 'url'
-corePath = require 'path'
-
 DEFAULT_HEADERS = require './default-headers'
+normalizeUrl = require 'normalizeurl'
 
-request = request.agent() if request.agent?
-
-# Superagent will only auto-parse responses from a Content-Type header it recognizes
-# Add the Accept in use by the JSON API spec, which is what will be sent back from the server
-request.parse[DEFAULT_HEADERS['Accept']] = JSON.parse
+if request.agent?
+  request = request.agent()
 
 makeHTTPRequest = (method, url, data, headers = {}, modify) ->
   originalArguments = Array::slice.call arguments # In case we need to retry
-
   method = method.toLowerCase()
+  url = normalizeUrl url
 
-  urlObject = coreUrl.parse url
-  urlObject.pathname = corePath.normalize urlObject.pathname
-  url = coreUrl.format urlObject
-
-  promise = new Promise (resolve, reject) ->
+  new Promise (resolve, reject) ->
     req = switch method
-            when 'get' then request.get(url).query(data)
-            when 'head' then request.head(url).query(data)
-            when 'put' then request.put(url).send(data)
-            when 'post' then request.post(url).send(data)
-            when 'delete' then request.del(url)
+      when 'get' then request.get(url).query data
+      when 'head' then request.head(url).query data
+      when 'put' then request.put(url).send data
+      when 'post' then request.post(url).send data
+      when 'delete' then request.del(url)
 
     req = req.set headers
-    req = req.withCredentials() if req.withCredentials?
-    req = modify request if modify?
 
-    req.end (err, response) ->
-      if err?.status is 408
+    if req.withCredentials?
+      req = req.withCredentials()
+
+    if modify?
+      console.warn 'Request modification is a sloppy idea; is anything actually doing this? Figure out something else.'
+      req = modify req
+
+    req.end (error, response) ->
+      if error?.status is 408
         makeHTTPRequest.apply null, originalArguments
-          .then resolve
-          .catch reject
-      else if err?
-        reject err
+      else if error?
+        reject response
       else
         resolve response
-
-  promise
 
 module.exports = makeHTTPRequest

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -31,7 +31,7 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
 
     req.end (error, response) ->
       if error?.status is 408
-        makeHTTPRequest.apply null, originalArguments
+        resolve makeHTTPRequest.apply null, originalArguments
       else if error?
         reject response
       else

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -5,6 +5,9 @@ normalizeUrl = require 'normalizeurl'
 if request.agent?
   request = request.agent()
 
+# Superagent will only auto-parse responses from a Content-Type header it recognizes.
+# Add the Accept in use by the JSON API spec, which is what will be sent back from the server.
+request.parse ?= {}
 request.parse[DEFAULT_HEADERS['Accept']] = JSON.parse.bind JSON
 
 makeHTTPRequest = (method, url, data, headers = {}, modify) ->

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -5,6 +5,8 @@ normalizeUrl = require 'normalizeurl'
 if request.agent?
   request = request.agent()
 
+request.parse[DEFAULT_HEADERS['Accept']] = JSON.parse.bind JSON
+
 makeHTTPRequest = (method, url, data, headers = {}, modify) ->
   originalArguments = Array::slice.call arguments # In case we need to retry
   method = method.toLowerCase()


### PR DESCRIPTION
The main change here is rejecting the _response_ instead of just the error so we can dig into the response body and build a more descriptive error message. This'll make a major version bump.

Also removed the standalone build script and cleaned up formatting to match conventions in the rest of the project.