### PR TITLE
Pre-join arrays in query values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JSON-API Client
 
-A client for the unfortunately named JSON API spec <http://jsonapi.org/>
+A client for the pre-release version of the JSON API spec <http://jsonapi.org/> used by Zooniverse Panoptes.
 
-Requires a native (or polyfilled) `Promise` class.
+Requires a native or polyfilled `Promise` class.
 
 ## Setting up a client
 

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -15,6 +15,10 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
   method = method.toLowerCase()
   url = normalizeUrl url
 
+  if method is 'get'
+    for key, value of data when Array.isArray value
+      data[key] = value.join ','
+
   new Promise (resolve, reject) ->
     req = switch method
       when 'get' then request.get(url).query data


### PR DESCRIPTION
superagent seems to expand array values into a query with duplicate keys.

`{slugs: ['a', 'b', 'c']}` would become `?slugs=a&slugs=b&slugs=c`.

Maybe that's HTML form style?

This makes it become `?slugs=a,b,c` like it used to.