### PR TITLE
Reject with the error if there's no response

### DIFF
--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -47,7 +47,9 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
       if error?.status is 408
         resolve makeHTTPRequest.apply null, originalArguments
       else if error?
-        reject response
+        # Prefer rejecting with the response, since it'll have more specific information.
+        # TODO: Reject with the error as expected and access the response through `error.response` in the handler.
+        reject response ? error
       else
         resolve response
 


### PR DESCRIPTION
If the error was that we couldn't make a request, we will certainly not get a response.

This fixes a bunch of nonsense errors being reported in the front end.