### PR TITLE
[WIP] use superagent cached get / head req’s

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "normalizeurl": "~0.1.3",
-    "superagent": "^1.3.0"
+    "superagent-cache": "^1.3.0"
   },
   "devDependencies": {
     "browserify": "^11.1.0",

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -1,4 +1,5 @@
-request = require 'superagent'
+cacheModuleConfig = { defaultExpiration: 10, verbose: true }
+request = require('superagent-cache')(null, cacheModuleConfig)
 DEFAULT_HEADERS = require './default-headers'
 normalizeUrl = require 'normalizeurl'
 


### PR DESCRIPTION
**DO NOT MERGE**

Looking to cut down the number of API req's and came across this module to auto cache GET / HEAD req's with superagent. I tried it out in PFE and it seems to work properly but I'm a little concerned about cache expiration timing especially on certain request routes like subjects, etc. Any thoughts on this? 

superagent-cache docs
https://github.com/jpodwys/superagent-cache#basic-usage

CacheModule docs 
https://github.com/jpodwys/cache-service-cache-module
