### PR TITLE
Remove unnecessary header on update

### DIFF
--- a/src/resource.coffee
+++ b/src/resource.coffee
@@ -200,8 +200,13 @@ class Resource extends Model
     delete @_linksCache[name]
 
   _getHeadersForModification: ->
-    'If-Unmodified-Since': @_getHeader 'Last-Modified'
-    'If-Match': @_getHeader 'ETag'
+    headers =
+      'If-Unmodified-Since': @_getHeader 'Last-Modified'
+      'If-Match': @_getHeader 'ETag'
+    for header, value of headers
+      unless value?
+        delete headers[header]
+    headers
 
   _getHeader: (header) ->
     header = header.toLowerCase()


### PR DESCRIPTION
When saving a record back to the API, the client adds two headers with values from when the subject was fetched: `If-Match` (using the `ETag` header value) and `If-Unmodified-Since` (using the `Last-Modified` header value). Panoptes doesn't send a `Last-Modified` header with subjects, so updating records will always fail (node catches the `undefined` set for `If-Unmodified-Since` and throws). I've therefore removed the `If-Unmodified-Since` header. It seems redundant if we're checking the `ETag` with `If-Match` anyway.