### PR TITLE
return error object with status and response

### DIFF
--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -28,6 +28,7 @@ class JSONAPIClient extends Model
     mergeInto this, mixins
 
   beforeEveryRequest: ->
+    console.log 'using local json-api-client'
     Promise.resolve();
 
   request: (method, url, payload, headers) ->
@@ -101,9 +102,9 @@ class JSONAPIClient extends Model
     if attributeTypeName?
       type._links[attributeName].type = attributeTypeName
 
-  handleError: ->
+  handleError: (err) ->
     # Override this as necessary.
-    Promise.reject arguments...
+    Promise.reject err
 
   type: (name) ->
     @_typesCache[name] ?= new Type name, this

--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -28,7 +28,7 @@ class JSONAPIClient extends Model
     mergeInto this, mixins
 
   beforeEveryRequest: ->
-    console.log 'using local json-api-client'
+    console.log 'using GitHub branch of json-api-client'
     Promise.resolve();
 
   request: (method, url, payload, headers) ->

--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -28,7 +28,6 @@ class JSONAPIClient extends Model
     mergeInto this, mixins
 
   beforeEveryRequest: ->
-    console.log 'using GitHub branch of json-api-client'
     Promise.resolve();
 
   request: (method, url, payload, headers) ->
@@ -102,9 +101,9 @@ class JSONAPIClient extends Model
     if attributeTypeName?
       type._links[attributeName].type = attributeTypeName
 
-  handleError: (err) ->
+  handleError: ->
     # Override this as necessary.
-    Promise.reject err
+    Promise.reject arguments...
 
   type: (name) ->
     @_typesCache[name] ?= new Type name, this

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -43,9 +43,7 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
       if error?.status is 408
         resolve makeHTTPRequest.apply null, originalArguments
       else if error?
-        # Prefer rejecting with the response, since it'll have more specific information.
-        # TODO: Reject with the error as expected and access the response through `error.response` in the handler.
-        reject response ? error
+        reject error
       else
         resolve response
 


### PR DESCRIPTION
See Issue #36.  

This PR would be the 1st PR to be merged of general error handling improvements.

### Please confirm my understanding:
Currently, if the error is a 4** ([other than 408](https://github.com/zooniverse/json-api-client/blob/master/src/make-http-request.coffee#L43)), 5** or other error it would be caught in `make-http-request` [line 45](https://github.com/zooniverse/json-api-client/blob/master/src/make-http-request.coffee#L45) and the [`handleError` function](https://github.com/zooniverse/json-api-client/blob/master/src/json-api-client.coffee#L104) in `json-api-client` would reject without returning anything.

However, the [`panoptes-javascript-client/api-client` `handleError` function](https://github.com/zooniverse/panoptes-javascript-client/blob/master/lib/api-client.js#L13) overrides the `json-api-client` error handler, checks if what it received was an error and if so throw it, otherwise it received a response (meaning a 4** [[but not 408](https://github.com/zooniverse/json-api-client/blob/master/src/make-http-request.coffee#L43)] or 5**) or something else, and based on that response or something else it crafts an error message to attempt to explain the error and then throws that error message (without status code or including the response object if there was one).

### Changes
The [error we're getting via superagent](https://github.com/zooniverse/json-api-client/blob/master/src/make-http-request.coffee#L41) has a `status` and `response` field as [they document here](https://visionmedia.github.io/superagent/#error-handling) and had been helpfully mentioned in the comments (thanks!). This PR changes it so the error object and only the error is returned, never the response, as the response (if present) is included as a field on the error object. Then in a related panoptes-javascript-client PR it should throw the error object, including status and response, or a generic error message.

### Initial Questions
1. The `panoptes-javascript-client` has additional error handling logic, or mostly just attempts to craft a more helpful error message, but we could: 

A. move any/all error handling logic and message crafting to the `json-api-client`
B. get rid of any/all error handling logic from the `panoptes-javascript-client` and just return the new error object and let PFE or whatever app is consuming the error handle error handling
C. improve the error handling logic and message in one the these repos based on status code (400 = "your request is bad," 500 = "your request might be good, but there's something wrong server-side," else = "good luck!")

2. How can I test how this handles a 5** error? Or more specifically does this solve [Jim's panoptes-javascript-client Issue 25](https://github.com/zooniverse/panoptes-javascript-client/issues/25)?