### PR TITLE
Bump version to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "normalizeurl": "~0.1.3",
-    "superagent": "^1.3.0"
+    "superagent": "^1.8.2"
   },
   "devDependencies": {
     "browserify": "^11.1.0",


### PR DESCRIPTION
Testing out bumping the superagent dependency to 1.8.2

Staged branch with the updated dep using this branch and one on the panoptes-javascript-client repo: https://try-bumped-superagent.pfe-preview.zooniverse.org/