### PR TITLE
Add query params to PUT and POST

### DIFF
--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -30,7 +30,7 @@ class JSONAPIClient extends Model
   beforeEveryRequest: ->
     Promise.resolve();
 
-  request: (method, url, payload, headers) ->
+  request: (method, url, payload, headers, query) ->
     @beforeEveryRequest().then =>
       method = method.toUpperCase()
       fullURL = @root + url
@@ -42,7 +42,7 @@ class JSONAPIClient extends Model
       else if method in WRITE_OPS
         @update writes: @writes + 1
 
-      request = makeHTTPRequest method, fullURL, fullPayload, allHeaders
+      request = makeHTTPRequest method, fullURL, fullPayload, allHeaders, query
 
       request
         .catch =>

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -12,7 +12,7 @@ if request.agent?
 request.parse ?= {}
 request.parse[DEFAULT_HEADERS['Accept']] = JSON.parse.bind JSON
 
-makeHTTPRequest = (method, url, data, headers = {}, modify) ->
+makeHTTPRequest = (method, url, data, headers = {}, query) ->
   originalArguments = Array::slice.call arguments # In case we need to retry
   method = method.toLowerCase()
   url = normalizeUrl url
@@ -29,8 +29,8 @@ makeHTTPRequest = (method, url, data, headers = {}, modify) ->
     req = switch method
       when 'get' then request.get(url).query data
       when 'head' then request.head(url).query data
-      when 'put' then request.put(url).send data
-      when 'post' then request.post(url).send data
+      when 'put' then request.put(url).query(query).send data
+      when 'post' then request.post(url).query(query).send data
       when 'delete' then request.del(url).query data
 
     req = req.set headers


### PR DESCRIPTION
Adds an optional query object argument to .save().
Passes that query down to the refresh() and request() methods so that query params can be added to the appropriate HTTP requests.

Closes #40 