### PR TITLE
Add optional query argument to Resource.delete()

### DIFF
--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -31,7 +31,7 @@ makeHTTPRequest = (method, url, data, headers = {}, query) ->
       when 'head' then request.head(url).query data
       when 'put' then request.put(url).query(query).send data
       when 'post' then request.post(url).query(query).send data
-      when 'delete' then request.del(url).query data
+      when 'delete' then request.del(url).query(query).query data
 
     req = req.set headers
 

--- a/src/resource.coffee
+++ b/src/resource.coffee
@@ -91,14 +91,14 @@ class Resource extends Model
     else
       throw new Error 'Can\'t uncache a resource with no ID'
 
-  delete: ->
+  delete: (query={})->
     @_write = @_write
       .catch =>
         null
       .then =>
         deletion = if @id
           @refresh(true, query).then =>
-            @_type._client.delete @_getURL(), null, @_getHeadersForModification()
+            @_type._client.delete @_getURL(), null, @_getHeadersForModification(), query
         else
           Promise.resolve()
 


### PR DESCRIPTION
Allow a query params object to be passed to DELETE requests.

Fixes #43