### PR TITLE
split makeHTTPRequest  to distinct methods

### DIFF
--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -110,7 +110,8 @@ class JSONAPIClient extends Model
     @_typesCache[name]
 
 module.exports = JSONAPIClient
-module.exports.makeHTTPRequest = makeHTTPRequest
+module.exports.makeHTTPRequest = makeHTTPRequest.makeHTTPRequest
+module.exports.makeCredentialHTTPRequest = makeHTTPRequest.makeCredentialHTTPRequest
 module.exports.Emitter = Emitter
 module.exports.Type = Type
 module.exports.Model = Model

--- a/src/json-api-client.coffee
+++ b/src/json-api-client.coffee
@@ -42,7 +42,7 @@ class JSONAPIClient extends Model
       else if method in WRITE_OPS
         @update writes: @writes + 1
 
-      request = makeHTTPRequest method, fullURL, fullPayload, allHeaders, query
+      request = makeHTTPRequest.makeHTTPRequest method, fullURL, fullPayload, allHeaders, query
 
       request
         .catch =>

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -17,7 +17,7 @@ makeHTTPRequest = (method, url, data, headers = {}, query) ->
 
 makeCredentialHTTPRequest = (method, url, data, headers = {}, query) ->
   if request.withCredentials?
-      request = request.withCredentials()
+    request = request.withCredentials()
   makeRequest(request, method, url, data, headers, query)
 
 makeRequest = (request, method, url, data, headers, query) ->

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -13,6 +13,14 @@ request.parse ?= {}
 request.parse[DEFAULT_HEADERS['Accept']] = JSON.parse.bind JSON
 
 makeHTTPRequest = (method, url, data, headers = {}, query) ->
+  makeRequest(request, method, url, data, headers = {}, query)
+
+makeCredentialHTTPRequest = (method, url, data, headers = {}, query) ->
+  if request.withCredentials?
+      request = request.withCredentials()
+  makeRequest(request, method, url, data, headers = {}, query)
+
+makeRequest = (request, method, url, data, headers = {}, query) ->
   originalArguments = Array::slice.call arguments # In case we need to retry
   method = method.toLowerCase()
   url = normalizeUrl url
@@ -35,9 +43,6 @@ makeHTTPRequest = (method, url, data, headers = {}, query) ->
 
     req = req.set headers
 
-    if req.withCredentials?
-      req = req.withCredentials()
-
     req.end (error, response) ->
       delete getsInProgress[requestID]
       if error?.status is 408
@@ -54,4 +59,4 @@ makeHTTPRequest = (method, url, data, headers = {}, query) ->
 
   promisedRequest
 
-module.exports = makeHTTPRequest
+module.exports = { makeHTTPRequest, makeCredentialHTTPRequest }

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -12,8 +12,14 @@ request.parse[DEFAULT_HEADERS['Accept']] = JSON.parse.bind JSON
 # isolate the credential requests from the superagent singleton
 # via the agent() to ensure correct credentials for both request types
 # http://visionmedia.github.io/superagent/#agents-for-global-state
-if request.agent? && request.withCredentials?
-  credentialRequest = request.agent().withCredentials()
+if request.agent?
+  credentialRequest = request.agent()
+  if credentialRequest.withCredentials?
+    credentialRequest = credentialRequest.withCredentials()
+else
+  # ensure the credentialRequest is set, though it would use the
+  # singleton superagent and fail to correctly send credential requests
+  credentialRequest = request
 
 makeHTTPRequest = (method, url, data, headers = {}, query) ->
   makeRequest(request, method, url, data, headers, query)

--- a/src/make-http-request.coffee
+++ b/src/make-http-request.coffee
@@ -13,14 +13,14 @@ request.parse ?= {}
 request.parse[DEFAULT_HEADERS['Accept']] = JSON.parse.bind JSON
 
 makeHTTPRequest = (method, url, data, headers = {}, query) ->
-  makeRequest(request, method, url, data, headers = {}, query)
+  makeRequest(request, method, url, data, headers, query)
 
 makeCredentialHTTPRequest = (method, url, data, headers = {}, query) ->
   if request.withCredentials?
       request = request.withCredentials()
-  makeRequest(request, method, url, data, headers = {}, query)
+  makeRequest(request, method, url, data, headers, query)
 
-makeRequest = (request, method, url, data, headers = {}, query) ->
+makeRequest = (request, method, url, data, headers, query) ->
   originalArguments = Array::slice.call arguments # In case we need to retry
   method = method.toLowerCase()
   url = normalizeUrl url


### PR DESCRIPTION
isolate the credentialed (user sessions) requests from non-credentialed (API) into distinct methods.

This will fix ensure we don't run across CORS errors when using credentialed XMLHTTPRequests for open (wildcard) cors origins and will whitelist allowed cors origins for credentialed resource requests