### PR TITLE
Update CHANGELOG with security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+[Full Changelog](https://github.com/zooniverse/json-api-client/compare/v5.0.2...master)
+
+**Security fixes:**
+
+- \[Security\] Bump path-parse from 1.0.5 to 1.0.7 [\#61](https://github.com/zooniverse/json-api-client/pull/61) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- \[Security\] Bump glob-parent from 5.1.0 to 5.1.2 [\#60](https://github.com/zooniverse/json-api-client/pull/60) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- \[Security\] Bump elliptic from 6.5.3 to 6.5.4 [\#59](https://github.com/zooniverse/json-api-client/pull/59) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- \[Security\] Bump tree-kill from 1.2.1 to 1.2.2 [\#58](https://github.com/zooniverse/json-api-client/pull/58) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
 ## [v5.0.2](https://github.com/zooniverse/json-api-client/tree/v5.0.2) (2020-08-03)
 
 [Full Changelog](https://github.com/zooniverse/json-api-client/compare/v5.0.1...v5.0.2)


### PR DESCRIPTION
Updates CHANGELOG with a few security updates from 2021.

With approval (and merge) of this PR, I'll bump the version to 5.0.3 and publish to `npm`. 

I think the process would be as follows, but good to confirm:

1. pull `master`, create `v5.0.3` (or similar named) branch
2. `npm rm -rf node_modules/ && npm ci` (with node 14, will change lockfileVersion to 2, prob few other lockfile changes)
3. `npm preversion`
4. update CHANGELOG to reflect v5.0.3
5. `npm version patch`
6. `npm publish`
7. `git push`
8. `git push --tags`
9. get `v5.0.3` reviewed/merged to `master` on GitHub