### PR TITLE
Update normalizeurl to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "json-api-client",
       "version": "5.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "normalizeurl": "~0.1.3",
+        "normalizeurl": "~1.0.0",
         "superagent": "^3.8.3"
       },
       "devDependencies": {
@@ -1239,9 +1240,9 @@
       }
     },
     "node_modules/normalizeurl": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-0.1.3.tgz",
-      "integrity": "sha1-7L7ntCghmlmXFVepf5tQ8ObOgHE="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-1.0.0.tgz",
+      "integrity": "sha1-SxpFjNDH0IVkNvaca1EEeraFUxc="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -2915,9 +2916,9 @@
       "dev": true
     },
     "normalizeurl": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-0.1.3.tgz",
-      "integrity": "sha1-7L7ntCghmlmXFVepf5tQ8ObOgHE="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-1.0.0.tgz",
+      "integrity": "sha1-SxpFjNDH0IVkNvaca1EEeraFUxc="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preversion": "npm run compile"
   },
   "dependencies": {
-    "normalizeurl": "~0.1.3",
+    "normalizeurl": "~1.0.0",
     "superagent": "^3.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## PR Overview

Part of a fix for https://github.com/zooniverse/panoptes-javascript-client/issues/153

This should fix the issue where projects with Webpack 5 can't sign in via oAuth due to the missing Node.js 'url' default library.

### Status

Ready for review. I need to bump the version and publish this, then bump PJC.